### PR TITLE
Add transcribeUrl method to Listen API for audio file transcription via URL

### DIFF
--- a/src/Api/Listen.php
+++ b/src/Api/Listen.php
@@ -107,9 +107,10 @@ class Listen
 
         $response = Http::withHeaders([
             'Authorization' => 'Token ' . $apiKey,
-            'Content-Type' => 'application/json',
-        ])->withBody(json_encode(['url' => $url]), 'application/json')
-            ->post($baseUrl . '/listen?' . $queryParams);
+        ])->post(
+                $baseUrl . '/listen?' . $queryParams,
+                ['url' => $url]
+            );
 
         return $response->throw()->json();
     }

--- a/src/Api/Listen.php
+++ b/src/Api/Listen.php
@@ -7,6 +7,7 @@ namespace DIJ\Deepgram\Api;
 use DIJ\Deepgram\Exceptions\DeepgramConfigurationException;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
+use InvalidArgumentException;
 use League\Flysystem\UnableToReadFile;
 
 class Listen
@@ -62,6 +63,53 @@ class Listen
             ->post($baseUrl . '/listen?' . $queryParams);
 
         fclose($stream);
+
+        return $response->throw()->json();
+    }
+
+    /**
+     * Transcribe remote audio file via URL using Deepgram /v1/listen API
+     *
+     * @param array<string, mixed> $options
+     * @return array<string, mixed>
+     *
+     * @throws DeepgramConfigurationException
+     * @throws InvalidArgumentException
+     * @throws RequestException
+     */
+    public function transcribeUrl(string $url, array $options = []): array
+    {
+        $apiKey = config('deepgram-laravel.api_key');
+        $baseUrl = mb_rtrim((string) config('deepgram-laravel.base_url'), '/');
+
+        if ($apiKey === null || $apiKey === '') {
+            throw new DeepgramConfigurationException('Deepgram API key is not properly configured');
+        }
+
+        if ($baseUrl === '') {
+            throw new DeepgramConfigurationException('Deepgram base URL is not properly configured');
+        }
+
+        if (filter_var($url, FILTER_VALIDATE_URL) === false) {
+            throw new InvalidArgumentException('Invalid audio URL format: ' . $url);
+        }
+
+        // Merge config defaults with provided options
+        $transcriptionOptions = array_merge([
+            'model' => config('deepgram-laravel.default_model', 'nova-2'),
+            'language' => config('deepgram-laravel.default_language', 'en-US'),
+        ], $options);
+
+        // Convert boolean values to string 'true'/'false' for Deepgram API
+        $transcriptionOptions = $this->convertBooleansToStrings($transcriptionOptions);
+
+        $queryParams = http_build_query($transcriptionOptions);
+
+        $response = Http::withHeaders([
+            'Authorization' => 'Token ' . $apiKey,
+            'Content-Type' => 'application/json',
+        ])->withBody(json_encode(['url' => $url]), 'application/json')
+            ->post($baseUrl . '/listen?' . $queryParams);
 
         return $response->throw()->json();
     }

--- a/src/Fakes/FakeListen.php
+++ b/src/Fakes/FakeListen.php
@@ -43,4 +43,42 @@ class FakeListen
             ],
         ];
     }
+
+    /**
+     * @param array<string, mixed> $options
+     * @return array<string, mixed>
+     */
+    public function transcribeUrl(string $url, array $options = []): array
+    {
+        return [
+            'metadata' => [
+                'transaction_key' => 'fake-transaction-' . uniqid(),
+                'request_id' => 'fake-request-' . uniqid(),
+                'sha256' => 'fake-sha256-hash',
+                'created' => date('c'),
+                'duration' => 10.5,
+                'channels' => 1,
+            ],
+            'results' => [
+                'channels' => [
+                    [
+                        'alternatives' => [
+                            [
+                                'transcript' => 'This is a fake transcription result.',
+                                'confidence' => 0.99,
+                                'words' => [
+                                    ['word' => 'This', 'start' => 0.0, 'end' => 0.3, 'confidence' => 0.99],
+                                    ['word' => 'is', 'start' => 0.3, 'end' => 0.4, 'confidence' => 0.99],
+                                    ['word' => 'a', 'start' => 0.4, 'end' => 0.5, 'confidence' => 0.99],
+                                    ['word' => 'fake', 'start' => 0.5, 'end' => 0.8, 'confidence' => 0.99],
+                                    ['word' => 'transcription', 'start' => 0.8, 'end' => 1.4, 'confidence' => 0.99],
+                                    ['word' => 'result.', 'start' => 1.4, 'end' => 1.8, 'confidence' => 0.99],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
 }

--- a/tests/Feature/Api/ListenTest.php
+++ b/tests/Feature/Api/ListenTest.php
@@ -335,7 +335,7 @@ describe('Listen API', function (): void {
                 // Verify HTTP request was made correctly
                 Http::assertSent(function ($request) use ($url): bool {
                     $requestUrl = $request->url();
-                    $body = json_decode($request->body(), true);
+                    $body = json_decode((string) $request->body(), true);
 
                     return str_contains($requestUrl, 'https://api.deepgram.com/v1/listen')
                         && str_contains($requestUrl, 'model=nova-2')
@@ -388,7 +388,7 @@ describe('Listen API', function (): void {
                 // Verify custom options were sent in query string with proper boolean conversion
                 Http::assertSent(function ($request) use ($url): bool {
                     $requestUrl = $request->url();
-                    $body = json_decode($request->body(), true);
+                    $body = json_decode((string) $request->body(), true);
 
                     return str_contains($requestUrl, 'model=nova-3')
                         && str_contains($requestUrl, 'language=en')
@@ -430,7 +430,7 @@ describe('Listen API', function (): void {
 
                 // Verify correct Content-Type header and URL in body
                 Http::assertSent(function ($request) use ($url): bool {
-                    $body = json_decode($request->body(), true);
+                    $body = json_decode((string) $request->body(), true);
 
                     return $request->header('Content-Type')[0] === 'application/json'
                         && isset($body['url'])
@@ -530,9 +530,9 @@ describe('Listen API', function (): void {
                 Http::assertSent(function ($request): bool {
                     $url = $request->url();
 
-                    return str_contains($url, 'model=nova-2') // from config
-                        && str_contains($url, 'language=en') // from options
-                        && str_contains($url, 'punctuate=true'); // from options (boolean converted to string)
+                    return str_contains((string) $url, 'model=nova-2') // from config
+                        && str_contains((string) $url, 'language=en') // from options
+                        && str_contains((string) $url, 'punctuate=true'); // from options (boolean converted to string)
                 });
             });
 
@@ -561,12 +561,12 @@ describe('Listen API', function (): void {
                 Http::assertSent(function ($request): bool {
                     $url = $request->url();
 
-                    return str_contains($url, 'smart_format=true')
-                        && str_contains($url, 'punctuate=false')
-                        && str_contains($url, 'diarize=true')
-                        && ! str_contains($url, 'smart_format=1')
-                        && ! str_contains($url, 'punctuate=0')
-                        && ! str_contains($url, 'diarize=1');
+                    return str_contains((string) $url, 'smart_format=true')
+                        && str_contains((string) $url, 'punctuate=false')
+                        && str_contains((string) $url, 'diarize=true')
+                        && ! str_contains((string) $url, 'smart_format=1')
+                        && ! str_contains((string) $url, 'punctuate=0')
+                        && ! str_contains((string) $url, 'diarize=1');
                 });
             });
         });

--- a/tests/Feature/Api/ListenTest.php
+++ b/tests/Feature/Api/ListenTest.php
@@ -7,6 +7,7 @@ use DIJ\Deepgram\Facades\Deepgram;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
+use InvalidArgumentException;
 use League\Flysystem\UnableToReadFile;
 
 beforeEach(function (): void {
@@ -210,7 +211,7 @@ describe('Listen API', function (): void {
         describe('options and configuration', function (): void {
             it('merges options correctly with config defaults', function (): void {
                 // ARRANGE
-                Storage::put('merge-test.wav', 'fake-audio-content');
+                Storage::put('merge-test.wav', 'fake-audio-content  ');
                 $audioFile = Storage::path('merge-test.wav');
 
                 Http::fake([
@@ -264,6 +265,290 @@ describe('Listen API', function (): void {
 
                 // ACT - Test both true and false boolean values
                 $result = Deepgram::listen()->transcribeFile($audioFile, 'audio/wav', [
+                    'smart_format' => true,
+                    'punctuate' => false,
+                    'diarize' => true,
+                ]);
+
+                // ASSERT
+                expect($result)->toBeArray();
+
+                // Verify boolean values are converted to 'true'/'false' strings, not '1'/'0'
+                Http::assertSent(function ($request): bool {
+                    $url = $request->url();
+
+                    return str_contains($url, 'smart_format=true')
+                        && str_contains($url, 'punctuate=false')
+                        && str_contains($url, 'diarize=true')
+                        && ! str_contains($url, 'smart_format=1')
+                        && ! str_contains($url, 'punctuate=0')
+                        && ! str_contains($url, 'diarize=1');
+                });
+            });
+        });
+    });
+
+    describe('transcribeUrl', function (): void {
+        describe('success cases', function (): void {
+            it('can transcribe audio URL with default config', function (): void {
+                // ARRANGE
+                $url = 'https://example.com/audio.wav';
+
+                Http::fake([
+                    'api.deepgram.com/v1/listen*' => Http::response([
+                        'metadata' => [
+                            'transaction_key' => 'deprecated',
+                            'request_id' => '12345',
+                            'sha256' => 'abc123',
+                            'created' => '2024-01-01T10:00:00.000Z',
+                            'duration' => 12.5,
+                            'channels' => 1,
+                        ],
+                        'results' => [
+                            'channels' => [
+                                [
+                                    'alternatives' => [
+                                        [
+                                            'transcript' => 'This is a test transcription from URL.',
+                                            'confidence' => 0.95,
+                                            'words' => [],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ], 200),
+                ]);
+
+                // ACT
+                $result = Deepgram::listen()->transcribeUrl($url);
+
+                // ASSERT
+                expect($result)->toBeArray()
+                    ->and($result['results']['channels'][0]['alternatives'][0]['transcript'])
+                    ->toBe('This is a test transcription from URL.')
+                    ->and($result['results']['channels'][0]['alternatives'][0]['confidence'])
+                    ->toBe(0.95)
+                    ->and($result['metadata']['duration'])
+                    ->toBe(12.5);
+
+                // Verify HTTP request was made correctly
+                Http::assertSent(function ($request) use ($url): bool {
+                    $requestUrl = $request->url();
+                    $body = json_decode($request->body(), true);
+
+                    return str_contains($requestUrl, 'https://api.deepgram.com/v1/listen')
+                        && str_contains($requestUrl, 'model=nova-2')
+                        && str_contains($requestUrl, 'language=en-US')
+                        && $request->header('Authorization')[0] === 'Token test-api-key'
+                        && $request->header('Content-Type')[0] === 'application/json'
+                        && isset($body['url'])
+                        && $body['url'] === $url;
+                });
+            });
+
+            it('can transcribe with custom options', function (): void {
+                // ARRANGE
+                $url = 'https://example.com/custom-audio.wav';
+
+                Http::fake([
+                    'api.deepgram.com/v1/listen*' => Http::response([
+                        'metadata' => ['duration' => 8.2],
+                        'results' => [
+                            'channels' => [
+                                [
+                                    'alternatives' => [
+                                        [
+                                            'transcript' => 'Custom transcription with diarization from URL.',
+                                            'confidence' => 0.98,
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ], 200),
+                ]);
+
+                $customOptions = [
+                    'model' => 'nova-3',
+                    'language' => 'en',
+                    'smart_format' => true,
+                    'punctuate' => true,
+                    'diarize' => true,
+                ];
+
+                // ACT
+                $result = Deepgram::listen()->transcribeUrl($url, $customOptions);
+
+                // ASSERT
+                expect($result)->toBeArray()
+                    ->and($result['results']['channels'][0]['alternatives'][0]['transcript'])
+                    ->toBe('Custom transcription with diarization from URL.');
+
+                // Verify custom options were sent in query string with proper boolean conversion
+                Http::assertSent(function ($request) use ($url): bool {
+                    $requestUrl = $request->url();
+                    $body = json_decode($request->body(), true);
+
+                    return str_contains($requestUrl, 'model=nova-3')
+                        && str_contains($requestUrl, 'language=en')
+                        && str_contains($requestUrl, 'smart_format=true')
+                        && str_contains($requestUrl, 'punctuate=true')
+                        && str_contains($requestUrl, 'diarize=true')
+                        && isset($body['url'])
+                        && $body['url'] === $url;
+                });
+            });
+
+            it('handles different URL formats correctly', function (): void {
+                // ARRANGE
+                $url = 'https://cdn.example.com/audio/mp3-file.mp3';
+
+                Http::fake([
+                    'api.deepgram.com/v1/listen*' => Http::response([
+                        'metadata' => ['duration' => 3.5],
+                        'results' => [
+                            'channels' => [
+                                [
+                                    'alternatives' => [
+                                        [
+                                            'transcript' => 'MP3 file transcribed from URL.',
+                                            'confidence' => 0.89,
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ], 200),
+                ]);
+
+                // ACT
+                $result = Deepgram::listen()->transcribeUrl($url);
+
+                // ASSERT
+                expect($result)->toBeArray();
+
+                // Verify correct Content-Type header and URL in body
+                Http::assertSent(function ($request) use ($url): bool {
+                    $body = json_decode($request->body(), true);
+
+                    return $request->header('Content-Type')[0] === 'application/json'
+                        && isset($body['url'])
+                        && $body['url'] === $url;
+                });
+            });
+        });
+
+        describe('error handling', function (): void {
+            it('throws configuration exception when api key is missing', function (): void {
+                // ARRANGE
+                config(['deepgram-laravel.api_key' => '']);
+                $url = 'https://example.com/audio.wav';
+
+                // ACT & ASSERT
+                expect(fn () => Deepgram::listen()->transcribeUrl($url))
+                    ->toThrow(DeepgramConfigurationException::class, 'Deepgram API key is not properly configured');
+            });
+
+            it('throws configuration exception when base url is empty', function (): void {
+                // ARRANGE
+                config(['deepgram-laravel.base_url' => '']);
+                $url = 'https://example.com/audio.wav';
+
+                // ACT & ASSERT
+                expect(fn () => Deepgram::listen()->transcribeUrl($url))
+                    ->toThrow(DeepgramConfigurationException::class, 'Deepgram base URL is not properly configured');
+            });
+
+            it('throws exception when URL is invalid format', function (): void {
+                // ARRANGE
+                $invalidUrl = 'not-a-valid-url';
+
+                // ACT & ASSERT
+                expect(fn () => Deepgram::listen()->transcribeUrl($invalidUrl))
+                    ->toThrow(InvalidArgumentException::class, 'Invalid audio URL format');
+            });
+
+            it('throws exception when URL is empty string', function (): void {
+                // ARRANGE
+                $emptyUrl = '';
+
+                // ACT & ASSERT
+                expect(fn () => Deepgram::listen()->transcribeUrl($emptyUrl))
+                    ->toThrow(InvalidArgumentException::class, 'Invalid audio URL format');
+            });
+
+            it('throws request exception when api returns error', function (): void {
+                // ARRANGE
+                $url = 'https://example.com/audio.wav';
+
+                Http::fake([
+                    'api.deepgram.com/v1/listen*' => Http::response([
+                        'error' => 'Invalid audio format',
+                    ], 400),
+                ]);
+
+                // ACT & ASSERT
+                expect(fn () => Deepgram::listen()->transcribeUrl($url))
+                    ->toThrow(RequestException::class);
+            });
+        });
+
+        describe('options and configuration', function (): void {
+            it('merges options correctly with config defaults', function (): void {
+                // ARRANGE
+                $url = 'https://example.com/merge-test.wav';
+
+                Http::fake([
+                    'api.deepgram.com/v1/listen*' => Http::response([
+                        'metadata' => ['duration' => 2.0],
+                        'results' => [
+                            'channels' => [
+                                [
+                                    'alternatives' => [
+                                        [
+                                            'transcript' => 'Options merged correctly from URL.',
+                                            'confidence' => 0.97,
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ], 200),
+                ]);
+
+                // ACT - Only override language, keep default model
+                $result = Deepgram::listen()->transcribeUrl($url, [
+                    'language' => 'en',
+                    'punctuate' => true,
+                ]);
+
+                // ASSERT
+                expect($result)->toBeArray();
+
+                // Verify that config defaults are kept and options are merged with proper boolean conversion
+                Http::assertSent(function ($request): bool {
+                    $url = $request->url();
+
+                    return str_contains($url, 'model=nova-2') // from config
+                        && str_contains($url, 'language=en') // from options
+                        && str_contains($url, 'punctuate=true'); // from options (boolean converted to string)
+                });
+            });
+
+            it('converts boolean values to string true/false for Deepgram API', function (): void {
+                // ARRANGE
+                $url = 'https://example.com/boolean-test.wav';
+
+                Http::fake([
+                    'api.deepgram.com/v1/listen*' => Http::response([
+                        'metadata' => ['duration' => 1.0],
+                        'results' => ['channels' => [['alternatives' => [['transcript' => 'Test', 'confidence' => 0.95]]]]],
+                    ], 200),
+                ]);
+
+                // ACT - Test both true and false boolean values
+                $result = Deepgram::listen()->transcribeUrl($url, [
                     'smart_format' => true,
                     'punctuate' => false,
                     'diarize' => true,


### PR DESCRIPTION
- Implemented transcribeUrl method in Listen class to allow transcription of remote audio files using the Deepgram API.
- Added error handling for missing API key, empty base URL, and invalid URL formats.
- Enhanced FakeListen class with a corresponding transcribeUrl method for testing purposes.
- Expanded ListenTest to include tests for transcribeUrl, covering success cases and error handling scenarios.